### PR TITLE
(Intiface Central) Update, fix Bluetooth permissions and add launcher script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-build
 .flatpak-builder/
+build/
+repo/

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,3 @@
-# ATLauncher
+# Intiface Central
 
 Flatpak for [Intiface Central](https://github.com/intiface/intiface-central)

--- a/com.nonpolynomial.intiface_central.desktop
+++ b/com.nonpolynomial.intiface_central.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Intiface Central
-Exec=intiface_central
+Exec=run_intiface_central
 Type=Application
 Icon=com.nonpolynomial.intiface_central

--- a/com.nonpolynomial.intiface_central.metainfo.xml
+++ b/com.nonpolynomial.intiface_central.metainfo.xml
@@ -27,7 +27,7 @@
     <release version="2.4.3" date="2023-07-23"/>
     <release version="2.3.0" date="2023-02-20"/>
   </releases>
-  
+
   <content_rating type="oars-1.1">
     <content_attribute id="sex-themes">moderate</content_attribute>
   </content_rating>

--- a/com.nonpolynomial.intiface_central.metainfo.xml
+++ b/com.nonpolynomial.intiface_central.metainfo.xml
@@ -2,30 +2,30 @@
 <!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <!-- Credits to github/nickavem for the app data, Doomsdayrs for edits -->
 <component type="desktop">
-    <id>com.nonpolynomial.intiface_central</id>
-    <metadata_license>MIT</metadata_license>
-    <name>Intiface Central</name>
-    <summary>Intiface® Central (Buttplug Frontend) Application for Desktop and Mobile </summary>
-    <description>
-        <p>Intiface® Central is a frontend application for the Buttplug Sex Toy Control Library, for Desktop (Win/macOS/Linux) and Mobile (Android/iOS).</p>
-        <p>For users, it provides simple, friendly capabilites for managing, connecting, customizing devices.</p>
-        <p>For developers, it allows their application to connect to and control sex toys, without having to worry about constantly updating the underlying libraries or dealing with bugs and crashes in a difficult-to-debug cross langauge environment.</p>
-    </description>
-    <url type="homepage">https://intiface.com/central/</url>
-    <url type="bugtracker">https://github.com/intiface/intiface-central/issues</url>
-    <url type="faq">https://how.do.i.get.buttplug.in/intiface/intiface-central.html</url>
-    <url type="help">https://discuss.buttplug.io/</url>
-    <!-- TODO translation? <url type="translate">https://translate.atlauncher.com/</url>-->
-    <url type="contact">https://github.com/qdot</url>
-    <launchable type="desktop-id">com.intiface.IntifaceCentral.desktop</launchable>
-    <project_license>GPL-3.0</project_license>
-    <developer_name>Nonpolynomial Labs, LLC</developer_name>
+  <id>com.nonpolynomial.intiface_central</id>
+  <metadata_license>MIT</metadata_license>
+  <name>Intiface Central</name>
+  <summary>Intiface® Central (Buttplug Frontend) Application for Desktop and Mobile</summary>
+  <description>
+    <p>Intiface® Central is a frontend application for the Buttplug Sex Toy Control Library, for Desktop (Win/macOS/Linux) and Mobile (Android/iOS).</p>
+    <p>For users, it provides simple, friendly capabilites for managing, connecting, customizing devices.</p>
+    <p>For developers, it allows their application to connect to and control sex toys, without having to worry about constantly updating the underlying libraries or dealing with bugs and crashes in a difficult-to-debug cross langauge environment.</p>
+  </description>
+  <url type="homepage">https://intiface.com/central/</url>
+  <url type="bugtracker">https://github.com/intiface/intiface-central/issues</url>
+  <url type="faq">https://how.do.i.get.buttplug.in/intiface/intiface-central.html</url>
+  <url type="help">https://discuss.buttplug.io/</url>
+  <url type="contact">https://github.com/qdot</url>
+  <launchable type="desktop-id">com.intiface.IntifaceCentral.desktop</launchable>
+  <project_license>GPL-3.0</project_license>
+  <developer_name>Nonpolynomial Labs, LLC</developer_name>
 
   <releases>
-        <release version="2.4.5" date="2023-10-09"/>
-        <release version="2.4.4" date="2023-10-06"/>
-        <release version="2.4.3" date="2023-07-23"/>
-        <release version="2.3.0" date="2023-02-20"/>
+    <release version="2.5.3" date="2023-11-17"/>
+    <release version="2.4.5" date="2023-10-09"/>
+    <release version="2.4.4" date="2023-10-06"/>
+    <release version="2.4.3" date="2023-07-23"/>
+    <release version="2.3.0" date="2023-02-20"/>
   </releases>
   
   <content_rating type="oars-1.1">

--- a/com.nonpolynomial.intiface_central.yaml
+++ b/com.nonpolynomial.intiface_central.yaml
@@ -8,11 +8,12 @@ sdk: org.freedesktop.Sdk
 command: intiface_central
 
 finish-args:
-  - --socket=wayland # Gamescope
-  - --share=network # Run server
-  - --allow=bluetooth
-  - --socket=system-bus
   - --device=dri
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --system-talk-name=org.bluez
 
 modules:
   - name: intiface

--- a/com.nonpolynomial.intiface_central.yaml
+++ b/com.nonpolynomial.intiface_central.yaml
@@ -5,7 +5,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
-command: intiface_central
+command: run_intiface_central
 
 finish-args:
   - --device=dri
@@ -19,31 +19,24 @@ modules:
   - name: intiface
     buildsystem: simple
     build-commands:
-      # Create bin
-      - mkdir -p /app/bin/
+      # Launcher
+      - install -Dt /app/bin/ run_intiface_central
 
-      # Move lib to proper directory
-      - mkdir -p /app/lib/
-      - mv lib/* /app/lib/
-      - ln -s /app/lib /app/bin/lib
-      #- mv lib /app/bin/
-      # Move data in
-      - mv data /app/bin/
-      - install -D intiface_central /app/bin/
+      # App
+      - install -Dt /app/lib/intiface_central/ intiface_central
+      - cp -r data /app/lib/intiface_central/
+      - cp -r lib /app/lib/intiface_central/
 
       # Metainfo
-      - mkdir -p /app/share/metainfo/
-      - install -D com.nonpolynomial.intiface_central.metainfo.xml /app/share/metainfo/
+      - install -Dt /app/share/metainfo/ com.nonpolynomial.intiface_central.metainfo.xml
 
-      # desktop
-      - mkdir -p /app/share/applications/
-      - install -D com.nonpolynomial.intiface_central.desktop /app/share/applications/
+      # Desktop
+      - install -Dt /app/share/applications/ com.nonpolynomial.intiface_central.desktop
 
       # Icon
-      - mkdir -p /app/share/icons/hicolor/scalable/apps
-      - install -D com.nonpolynomial.intiface_central.svg /app/share/icons/hicolor/scalable/apps/
+      - install -Dt /app/share/icons/hicolor/scalable/apps/ com.nonpolynomial.intiface_central.svg
     sources:
-      # Logo
+      # Icon
       - type: file
         url: https://raw.githubusercontent.com/intiface/intiface-central/dev/assets/icons/intiface_central_icon.svg
         dest-filename: com.nonpolynomial.intiface_central.svg
@@ -67,3 +60,7 @@ modules:
           version-query: .name | sub("^.*v"; "")
           url-query: .assets[] | select(.name=="intiface-central-v" + $version + "-linux-ubuntu-22.04-x64.zip")
             | .browser_download_url
+
+      # Launcher
+      - type: file
+        path: run_intiface_central

--- a/com.nonpolynomial.intiface_central.yaml
+++ b/com.nonpolynomial.intiface_central.yaml
@@ -2,7 +2,7 @@
 
 app-id: com.nonpolynomial.intiface_central
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
 command: intiface_central

--- a/com.nonpolynomial.intiface_central.yaml
+++ b/com.nonpolynomial.intiface_central.yaml
@@ -58,12 +58,11 @@ modules:
 
       # App
       - type: archive
-        url: https://github.com/intiface/intiface-central/releases/download/v2.4.5/intiface-central-v2.4.5-linux-x64.zip
-        tag: v2.3.0
-        sha256: 58421cdc163948b4038ad8879469b7636a7a35f566f07e6859124e6c18290668
+        url: https://github.com/intiface/intiface-central/releases/download/v2.5.3/intiface-central-v2.5.3-linux-ubuntu-22.04-x64.zip
+        sha256: cdbef06755f2a618af095237c00d13d815ef258c2c45eee10f1bb2d626d3dc1d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/intiface/intiface-central/releases/latest
           version-query: .name | sub("^.*v"; "")
-          url-query: .assets[] | select(.name=="intiface-central-v" + $version + "-linux-x64.zip")
+          url-query: .assets[] | select(.name=="intiface-central-v" + $version + "-linux-ubuntu-22.04-x64.zip")
             | .browser_download_url

--- a/run_intiface_central
+++ b/run_intiface_central
@@ -1,0 +1,8 @@
+#!/bin/sh
+# (script copied from https://aur.archlinux.org/packages/intiface-central-bin)
+# Because of issue #40 on GitHub, intiface_central needs to be executed
+# in the folder containing the 'lib' subdirectory as library loading
+# from LD_LIBRARY_PATH is not supported.
+
+cd /app/lib/intiface_central/
+./intiface_central


### PR DESCRIPTION
* Update Intiface Central to `v2.5.3`
* Update runtime to `23.08`
* Remove permissions
  * `--allow=bluetooth`: [only required for direct access to Bluetooth sockets](https://www.apertis.org/architecture/flatpak-overview/#devices)
  * `--socket=system-bus`: advised against by Flatpak docs
* Add permissions
  * `--share=ipc`, `--socket=fallback-x11`: required to run on X11
  * `--system-talk-name=org.bluez`: [required for access to BlueZ D-Bus service](https://www.apertis.org/architecture/flatpak-overview/#devices) (btleplug seems to use this, see first bullet point under "Async Despite Best Efforts" in [this blogpost](https://nonpolynomial.com/2023/10/30/how-to-beg-borrow-steal-your-way-to-a-cross-platform-bluetooth-le-library/))
* Add launcher script in `/app/bin/`, move all of Intiface Central to `/app/lib/intiface_central/` as a more elegant solution than symlinking the `lib` directory (this is similar to what the [AUR package](https://aur.archlinux.org/packages/intiface-central-bin) does; I also "borrowed" the script from there :D)

Adding `--system-talk-name=org.bluez` (or not removing `--socket=system-bus`) has fixed the issue with Intiface Central hanging at startup for me.